### PR TITLE
Include esbuild as a peer dependencie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@aligent/aws-prerender-proxy-stack",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@aws-cdk/aws-cloudfront": "^1.111.0",
@@ -24,6 +24,9 @@
         "ts-jest": "^26.5.4",
         "ts-node": "^10.0.0",
         "typescript": "^4.3.5"
+      },
+      "peerDependencies": {
+        "esbuild": "^0.12.15"
       }
     },
     "node_modules/@aws-cdk/assert": {
@@ -4284,6 +4287,16 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
+      "integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
+      "hasInstallScript": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
       }
     },
     "node_modules/escalade": {
@@ -11986,6 +11999,12 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "esbuild": {
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
+      "integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
+      "peer": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "ts-node": "^10.0.0",
     "typescript": "^4.3.5"
   },
+  "peerDependencies": {
+    "esbuild": "^0.12.15"
+  },
   "dependencies": {
     "@aws-cdk/aws-cloudfront": "^1.111.0",
     "@aws-cdk/aws-lambda": "^1.111.0",


### PR DESCRIPTION
`esbuild` is required to bundle the lambda functions.
This PR includes it as a dependency without interfering with upstream `esbuild` packages. 